### PR TITLE
add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,59 @@
+language: python
+sudo: false
+cache:
+  pip: true
+  directories:
+    - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
+
+env:
+  global:
+    NUMPY=numpy
+    CYTHON=cython
+    MATPLOTLIB=matplotlib
+
+matrix:
+  include:
+    - python: 2.7
+      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - os: osx
+      osx_image: xcode7.3
+      language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
+      cache:
+        pip: false
+        directories:
+          - $HOME/Library/Caches/pip
+          # `cache` does not support `env`-like `global` so copy-paste from top
+          - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
+
+before_install:
+  - |
+    if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
+      pip install --upgrade virtualenv
+      python -m virtualenv venv
+      source venv/bin/activate
+      export PATH=/usr/lib/ccache:$PATH
+    else
+      brew update
+      export PATH=/usr/local/opt/ccache/libexec:$PATH
+    fi
+
+install:
+  - |
+    # setup environment
+    ccache -s
+    # Upgrade pip and setuptools and wheel to get clean install
+    pip install --upgrade pip
+    pip install --upgrade wheel
+    pip install --upgrade setuptools
+    # Install dependencies
+    pip install mock $NUMPY $CYTHON $MATPLOTLIB nose
+    # install cykdtree
+    pip install -e .
+
+script:
+  - |
+    nosetests --nologcapture -sv cykdtree

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     NUMPY=numpy
     CYTHON=cython
     MATPLOTLIB=matplotlib
+    MPLBACKEND=agg
 
 matrix:
   include:
@@ -45,9 +46,6 @@ install:
   - |
     # setup environment
     ccache -s
-    # tell matplotlib to use the agg backend
-    echo "backend : Agg" > $HOME/.matplotlibrc
-    cat $HOME/.matplotlibrc
     # Upgrade pip and setuptools and wheel to get clean install
     pip install --upgrade pip
     pip install --upgrade wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,14 @@ install:
   - |
     # setup environment
     ccache -s
+    # tell matplotlib to use the agg backend
+    echo "backend : Agg" > $HOME/.matplotlibrc
     # Upgrade pip and setuptools and wheel to get clean install
     pip install --upgrade pip
     pip install --upgrade wheel
     pip install --upgrade setuptools
     # Install dependencies
-    pip install mock $NUMPY $CYTHON $MATPLOTLIB nose
+    pip install $NUMPY $CYTHON $MATPLOTLIB nose
     # install cykdtree
     pip install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
     ccache -s
     # tell matplotlib to use the agg backend
     echo "backend : Agg" > $HOME/.matplotlibrc
+    cat $HOME/.matplotlibrc
     # Upgrade pip and setuptools and wheel to get clean install
     pip install --upgrade pip
     pip install --upgrade wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
       export PATH=/usr/lib/ccache:$PATH
     else
       brew update
+      brew install ccache
       export PATH=/usr/local/opt/ccache/libexec:$PATH
     fi
 

--- a/cykdtree/utils.pyx
+++ b/cykdtree/utils.pyx
@@ -8,9 +8,6 @@ from libc.stdint cimport uint32_t, uint64_t, int64_t, int32_t
 
 import copy
 
-import scipy
-from scipy.sparse import csr_matrix
-
 def py_max_pts(np.ndarray[np.float64_t, ndim=2] pos):
     r"""Get the maximum of points along each coordinate. 
 


### PR DESCRIPTION
This sets up a build matrix with 6 jobs:

* Python 2.7 with minimal (oldish) dependencies
* Python 2.7 with latest dependencies
* Python 3.4
* Python 3.5
* Python 3.6
* Python 3.6 on MacOS

All jobs except for the last one are on Linux.