### PR TITLE
fix building under windows on python 3.6

### DIFF
--- a/cykdtree/c_kdtree.hpp
+++ b/cykdtree/c_kdtree.hpp
@@ -22,14 +22,14 @@ void serialize_scalar(std::ostream &os, const T &scalar) {
 }
 
 template <typename T>
-T* deserialize_pointer_array(std::istream &is, uint32_t len) {
+T* deserialize_pointer_array(std::istream &is, uint64_t len) {
   T* arr = (T*)malloc(len*sizeof(T));
   is.read((char*)&arr[0], len*sizeof(T));
   return arr;
 }
 
 template <typename T>
-void serialize_pointer_array(std::ostream &os, const T* array, uint32_t len) {
+void serialize_pointer_array(std::ostream &os, const T* array, uint64_t len) {
   os.write((char*)array, len*sizeof(T));
 }
 
@@ -370,7 +370,7 @@ public:
   }
 
   void select_unique_neighbors() {
-    if (not is_leaf)
+    if (!is_leaf)
       return;
 
     uint32_t d;
@@ -388,7 +388,7 @@ public:
   }
 
   void join_neighbors() {
-    if (not is_leaf)
+    if (!is_leaf)
       return;
 
     uint32_t d;
@@ -769,11 +769,11 @@ public:
     for (i = 0; i < num_leaves; i++) {
       leaf = leaves[i];
       for (d0 = 0; d0 < ndim; d0++) {
-	if (not leaf->periodic_left[d0])
+	if (!leaf->periodic_left[d0])
 	  continue;
 	for (j = i; j < num_leaves; j++) {
 	  prev = leaves[j];
-	  if (not prev->periodic_right[d0])
+	  if (!prev->periodic_right[d0])
 	    continue;
 	  add_neighbors_periodic(leaf, prev, d0);
 	}
@@ -784,9 +784,9 @@ public:
   void add_neighbors_periodic(Node *leaf, Node *prev, uint32_t d0) {
     uint32_t d, ndim_escape;
     bool match;
-    if (not leaf->periodic_left[d0])
+    if (!leaf->periodic_left[d0])
       return;
-    if (not prev->periodic_right[d0])
+    if (!prev->periodic_right[d0])
       return;
     match = true;
     ndim_escape = 0;
@@ -810,7 +810,7 @@ public:
 	}
       }
     }
-    if ((match) and (ndim_escape < (ndim-1))) {
+    if ((match) && (ndim_escape < (ndim-1))) {
       // printf("%d: %d, %d (%d)\n", d0, leaf->leafid, prev->leafid, ndim_escape);
       leaf->left_neighbors[d0].push_back(prev->leafid);
       prev->right_neighbors[d0].push_back(leaf->leafid);

--- a/cykdtree/c_utils.cpp
+++ b/cykdtree/c_utils.cpp
@@ -208,7 +208,7 @@ uint32_t split(double *all_pts, uint64_t *all_idx,
                int64_t &split_idx, double &split_val,
 	       bool use_sliding_midpoint) {
   // Return immediately if variables empty
-  if ((n == 0) or (ndim == 0)) {
+  if ((n == 0) || (ndim == 0)) {
     split_idx = -1;
     split_val = 0.0;
     return 0;

--- a/cykdtree/utils.pyx
+++ b/cykdtree/utils.pyx
@@ -66,7 +66,7 @@ def py_argmax_pts_dim(np.ndarray[np.float64_t, ndim=2] pos,
             indices along dimension d.
 
     """
-    cdef int n = pos.shape[0]
+    cdef np.intp_t n = pos.shape[0]
     cdef uint32_t m = <uint32_t>pos.shape[1]
     cdef uint64_t Lidx = 0
     cdef uint64_t Ridx = <uint64_t>(n-1)
@@ -135,7 +135,7 @@ def py_quickSort(np.ndarray[np.float64_t, ndim=2] pos, np.uint32_t d):
         np.ndarray of uint64: Indices that sort pos along dimension d.
 
     """
-    cdef uint32_t ndim = pos.shape[1]
+    cdef np.intp_t ndim = pos.shape[1]
     cdef int64_t l = 0
     cdef int64_t r = pos.shape[0]-1
     cdef uint64_t[:] idx
@@ -159,7 +159,7 @@ def py_insertSort(np.ndarray[np.float64_t, ndim=2] pos, np.uint32_t d):
         np.ndarray of uint64: Indices that sort pos along dimension d.
 
     """
-    cdef uint32_t ndim = pos.shape[1]
+    cdef np.intp_t ndim = pos.shape[1]
     cdef int64_t l = 0
     cdef int64_t r = pos.shape[0]-1
     cdef uint64_t[:] idx
@@ -187,7 +187,7 @@ def py_pivot(np.ndarray[np.float64_t, ndim=2] pos, np.uint32_t d):
             be the median.
 
     """
-    cdef uint32_t ndim = pos.shape[1]
+    cdef np.intp_t ndim = pos.shape[1]
     cdef int64_t l = 0
     cdef int64_t r = pos.shape[0]-1
     cdef uint64_t[:] idx
@@ -217,7 +217,7 @@ def py_partition(np.ndarray[np.float64_t, ndim=2] pos, np.uint32_t d,
             the pivot are larger.
 
     """
-    cdef uint32_t ndim = pos.shape[1]
+    cdef np.intp_t ndim = pos.shape[1]
     cdef int64_t l = 0
     cdef int64_t r = pos.shape[0]-1
     cdef uint64_t[:] idx
@@ -246,7 +246,7 @@ def py_partition_given_pivot(np.ndarray[np.float64_t, ndim=2] pos,
             are smaller and elements after the pivot are larger.
 
     """
-    cdef uint32_t ndim = pos.shape[1]
+    cdef np.intp_t ndim = pos.shape[1]
     cdef int64_t l = 0
     cdef int64_t r = pos.shape[0]-1
     cdef uint64_t[:] idx
@@ -278,7 +278,7 @@ def py_select(np.ndarray[np.float64_t, ndim=2] pos, np.uint32_t d,
             the pivot are larger.
 
     """
-    cdef uint32_t ndim = pos.shape[1]
+    cdef np.intp_t ndim = pos.shape[1]
     cdef int64_t l = 0
     cdef int64_t r = pos.shape[0]-1
     cdef uint64_t[:] idx
@@ -314,8 +314,8 @@ def py_split(np.ndarray[np.float64_t, ndim=2] pos,
             required to partition the array.
 
     """
-    cdef uint64_t npts = pos.shape[0]
-    cdef uint32_t ndim = pos.shape[1]
+    cdef np.intp_t npts = pos.shape[0]
+    cdef np.intp_t ndim = pos.shape[1]
     cdef uint64_t Lidx = 0
     cdef uint64_t[:] idx
     idx = np.arange(pos.shape[0]).astype('uint64')

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from subprocess import Popen, PIPE
 import copy
 import numpy
 import os
+import platform
 
 # Set to false to enable tracking of Cython lines in profile
 release = True
@@ -55,6 +56,9 @@ if RTDFLAG:
     ext_options['libraries'] = []
     ext_options['extra_link_args'] = []
     ext_options['extra_compile_args'].append('-DREADTHEDOCS')
+    compile_parallel = False
+elif platform.system() == 'Windows':
+    # AFAICS MPI is not supported well on Windows.
     compile_parallel = False
 else:
     try:


### PR DESCRIPTION
The pertinent changes for building are e.g. replacing `and` with `&&`. The changes to integer types are to suppress warnings about precision loss.

With this I'm able to build cykdtree under Python3.6 on Windows 10. As far as I can see MPI isn't supported very well on Windows so I've added a check to `setup.py` that suppressed building the parallel KDTree on Windows.